### PR TITLE
MacOS binaries reinstallation not working

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -54,8 +54,10 @@
     ]
   },
   "pkg": {
+    "installLocation": "/Applications",
     "scripts": "pkg-scripts",
     "allowAnywhere": false,
-    "allowCurrentUserHome": false
+    "allowCurrentUserHome": false,
+    "isRelocatable": false
   }
 }


### PR DESCRIPTION
After remove ReelSteady Joiner from Applications the next install doesn't create the new .app