### PR TITLE
Fix first launch error reading config file

### DIFF
--- a/app/src/provider/Config.js
+++ b/app/src/provider/Config.js
@@ -46,9 +46,11 @@ class Config {
     }
 
     saveConfig() {
-        fs.writeFile(path.join(CONFIG_DIR, CONFIG_FILE), JSON.stringify(this), (err) => {
-            if (err) throw new ConfigSaveError('Unable to save settings');
-        });
+        try {
+            fs.writeFileSync(path.join(CONFIG_DIR, CONFIG_FILE), JSON.stringify(this));
+        } catch (_) {
+            throw new ConfigSaveError('Unable to save settings');
+        }
     }
 }
 


### PR DESCRIPTION
When using an asynchronous method to save the configuration file and later try to read it, it could be the case that the configuration file does not exist yet or that the configuration file does not have all the required information