### PR TITLE
Add new option to disable date modification

### DIFF
--- a/app/assets/style/app.css
+++ b/app/assets/style/app.css
@@ -693,6 +693,67 @@ img.openExternal:hover {
     opacity: 1;
 }
 
+.switch {
+    position: absolute;
+    display: inline-block;
+    width: 48px;
+    height: 28px;
+    margin-top: -14px;
+    margin-left: -48px;
+}
+
+.switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    -webkit-transition: .4s;
+    transition: .4s;
+}
+
+.slider:before {
+    position: absolute;
+    content: "";
+    height: 20px;
+    width: 20px;
+    left: 4px;
+    bottom: 4px;
+    background-color: white;
+    -webkit-transition: .4s;
+    transition: .4s;
+}
+
+input:checked + .slider {
+    background-color: #e67e22;
+}
+
+input:focus + .slider {
+    box-shadow: 0 0 1px #e67e22;
+}
+
+input:checked + .slider:before {
+    -webkit-transform: translateX(20px);
+    -ms-transform: translateX(20px);
+    transform: translateX(20px);
+}
+
+.slider.round {
+    border-radius: 34px;
+}
+
+.slider.round:before {
+    border-radius: 50%;
+}
+
 select {
     background-color: rgba(99, 110, 114, 0.3);
     background-image: url("data:image/svg+xml,%3Csvg width='24px' height='24px' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='%23ebe5d6' d='M22.987 10.25l-9 7.99c-.57.51-1.28.76-1.99.76s-1.42-.25-1.98-.74c0-.01-.01-.01-.01-.01l-.02-.02-8.98-7.98c-1.24-1.1-1.35-3.002-.25-4.242 1.1-1.24 3-1.35 4.23-.25l7.01 6.23 7.01-6.23c1.24-1.1 3.13-.99 4.24.25 1.1 1.24.98 3.13-.26 4.24z'/%3E%3C/svg%3E");

--- a/app/render.js
+++ b/app/render.js
@@ -32,6 +32,7 @@ const openLogsPathBtn = ui.get('openLogsPathBtn');
 const projectSavePathBtn = ui.get('projectSavePathBtn');
 const projectSavePathContainer = ui.get('projectSavePathOptionContainer');
 const projectExportOptions = ui.get('projectExportOptions');
+const fileModifyDatesOption  = ui.get('fileModifyDatesOption');
 const projectContainer = ui.get('projectContainer');
 const concurrentDownBtn = ui.get('concurrentDownBtn');
 const concurrentUpBtn = ui.get('concurrentUpBtn');
@@ -100,6 +101,10 @@ ui.onChange(projectExportOptions, () => {
 
 ui.onClick(projectSavePathBtn, () => {
     ipcRenderer.send('showLogsPathDialog');
+});
+
+ui.onClick(fileModifyDatesOption, function(e) {
+    ipcRenderer.send('updateConfig', {'key': 'fileModifyDates', 'value': e.target.checked});
 });
 
 ui.onClick(document, (event) => {
@@ -256,11 +261,13 @@ ipcRenderer.on('processVideosFinished', () => {
     ui.enable(concurrentUpBtn);
     ui.enable(concurrentDownBtn);
     ui.enable(projectExportOptions);
+    ui.enable(fileModifyDatesOption);
 });
 
 ipcRenderer.on('processVideosStarted', () => {
     ui.disable(selectFileBtn);
     ui.disable(projectExportOptions);
+    ui.disable(fileModifyDatesOption);
     ui.disable(processVideosBtn);
     ui.disable(projectSavePathBtn);
     ui.disable(concurrentUpBtn);
@@ -358,6 +365,8 @@ function updateConfigDOM() {
             ui.show(projectSavePathContainer);
             break;
     }
+
+    fileModifyDatesOption.checked = config.fileModifyDates;
 }
 
 /**

--- a/app/src/provider/Config.js
+++ b/app/src/provider/Config.js
@@ -17,6 +17,7 @@ class Config {
         this.savePath = '';
         this.exportOption = 0;
         this.concurrentProjects = 1;
+        this.fileModifyDates = 1;
     }
 
     loadConfig() {

--- a/app/src/provider/VideoProcessor.js
+++ b/app/src/provider/VideoProcessor.js
@@ -50,9 +50,13 @@ class VideoProcessor {
     static async startProcessing(project, event) {
         this.createLog(project);
         return new Promise((resolve, reject) => {
-            const waitFor = (cd, cb) => { cd() ? cb() : setTimeout(waitFor.bind(null, cd, cb), 250) };
+            const waitFor = (cd, cb) => {
+                cd() ? cb() : setTimeout(waitFor.bind(null, cd, cb), 250)
+            };
 
-            waitFor(() => { return project.available }, () => {
+            waitFor(() => {
+                return project.available
+            }, () => {
                 event.sender.send('setMaxProjectProgress', {'id': project.id, 'max': project.duration});
                 let projectError = false;
 
@@ -64,7 +68,9 @@ class VideoProcessor {
                 this.logProjectInfo(project, outputName, concatFilePath, outputFilePath);
 
                 this.getAllStreamMaps(project, concatFilePath).then(streamMaps => {
-                    return streamMaps.map((m) => { return `-map 0:${m}` });
+                    return streamMaps.map((m) => {
+                        return `-map 0:${m}`
+                    });
                 }).catch((e) => {
                     projectError = true;
                     reject(e);
@@ -81,8 +87,12 @@ class VideoProcessor {
                         new ffmpeg(concatFilePath)
                             .on('progress', (progress) => {
                                 try {
-                                    event.sender.send('updateProjectProgress', {'id': project.id, 'progress': progress});
-                                } catch (_) {} //Skip error when killing ffmpeg process on application close
+                                    event.sender.send('updateProjectProgress', {
+                                        'id': project.id,
+                                        'progress': progress
+                                    });
+                                } catch (_) {
+                                } //Skip error when killing ffmpeg process on application close
                             })
                             .on('error', (err, stdout, stderr) => {
                                 reject({'err': err, 'stdout': stdout, 'stderr': stderr});
@@ -302,14 +312,18 @@ class VideoProcessor {
      */
     static async setCustomMetadata(project, outputVideo) {
         return new Promise(resolve => {
-            const exec = execFile(exiftool, [
-                '-config',
-                exifToolConfigPath,
-                `-FileModifyDate="${project.modifiedDate}"`,
-                outputVideo
-            ], resolve);
+            if (config.fileModifyDates) {
+                const exec = execFile(exiftool, [
+                    '-config',
+                    exifToolConfigPath,
+                    `-FileModifyDate="${project.modifiedDate}"`,
+                    outputVideo
+                ], resolve);
 
-            project.log.debug(`customMetadata: ${JSON.stringify(exec)}`);
+                project.log.debug(`customMetadata: ${JSON.stringify(exec)}`);
+            } else {
+                resolve();
+            }
         });
     }
 
@@ -446,11 +460,11 @@ class VideoProcessor {
                 .on('end', () => {
                     resolve(path.join(os.tmpdir(), `${uuid}.png`));
                 })
-                .on('error', function(err, stdout, stderr) {
+                .on('error', function (err, stdout, stderr) {
                     reject({'error': err, 'stdout': stdout, 'stderr': stderr});
                 })
                 .takeScreenshots({
-                    timemarks: [ '00:00:00.000' ],
+                    timemarks: ['00:00:00.000'],
                     filename: `${uuid}.png`,
                     folder: os.tmpdir(),
                     size: '320x240'

--- a/app/templates/index-mac.html
+++ b/app/templates/index-mac.html
@@ -95,6 +95,22 @@
     <div class="configLine">
         <div class="configLineContent">
             <div>
+                <div class="configName">Modify file dates</div>
+                <div class="configDescription">
+                    If enabled, the date of the output file will be the same as the date of the first video file
+                </div>
+            </div>
+            <div class="d-flex vertical-center">
+                <label class="switch">
+                    <input type="checkbox" id="fileModifyDatesOption">
+                    <span class="slider round"></span>
+                </label>
+            </div>
+        </div>
+    </div>
+    <div class="configLine">
+        <div class="configLineContent">
+            <div>
                 <div class="configName">Logs</div>
                 <div class="configDescription">
                     Open the path where the logs are stored

--- a/app/templates/index-win.html
+++ b/app/templates/index-win.html
@@ -98,6 +98,22 @@
     <div class="configLine">
         <div class="configLineContent">
             <div>
+                <div class="configName">Modify file dates</div>
+                <div class="configDescription">
+                    If enabled, the date of the output file will be the same as the date of the first video file
+                </div>
+            </div>
+            <div class="d-flex vertical-center">
+                <label class="switch">
+                    <input type="checkbox" id="fileModifyDatesOption">
+                    <span class="slider round"></span>
+                </label>
+            </div>
+        </div>
+    </div>
+    <div class="configLine">
+        <div class="configLineContent">
+            <div>
                 <div class="configName">Logs</div>
                 <div class="configDescription">
                     Open the path where the logs are stored


### PR DESCRIPTION
Add new option to disable date modification of output file, preserving the original generation date of the output file.

Described in #54 

This improvement will be added in version 1.3.2

